### PR TITLE
[qtwebkit] Disable text auto correction by default

### DIFF
--- a/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview_p.h
+++ b/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview_p.h
@@ -257,6 +257,8 @@ class QWEBKIT_EXPORT QQuickWebViewExperimental : public QObject {
     Q_PROPERTY(int deviceWidth WRITE setDeviceWidth READ deviceWidth NOTIFY deviceWidthChanged)
     Q_PROPERTY(int deviceHeight WRITE setDeviceHeight READ deviceHeight NOTIFY deviceHeightChanged)
 
+    Q_PROPERTY(bool autoCorrect WRITE setAutoCorrect READ autoCorrect NOTIFY autoCorrectChanged)
+
     Q_PROPERTY(QWebNavigationHistory* navigationHistory READ navigationHistory CONSTANT FINAL)
 
     Q_PROPERTY(QQmlComponent* alertDialog READ alertDialog WRITE setAlertDialog NOTIFY alertDialogChanged)
@@ -338,6 +340,9 @@ public:
     int preferredMinimumContentsWidth() const;
     void setPreferredMinimumContentsWidth(int);
 
+    bool autoCorrect() const;
+    void setAutoCorrect(bool autoCorrect);
+
     // C++ only
     bool renderToOffscreenBuffer() const;
     void setRenderToOffscreenBuffer(bool enable);
@@ -373,6 +378,7 @@ Q_SIGNALS:
     void userScriptsChanged();
     void preferredMinimumContentsWidthChanged();
     void remoteInspectorUrlChanged();
+    void autoCorrectChanged();
 
 private:
     QQuickWebViewExperimental(QQuickWebView* webView, QQuickWebViewPrivate* webViewPrivate);

--- a/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview_p_p.h
+++ b/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview_p_p.h
@@ -122,6 +122,9 @@ public:
     void setNavigatorQtObjectEnabled(bool);
     void updateUserScripts();
 
+    void setAutoCorrect(bool autoCorrect) { m_autoCorrect = autoCorrect; }
+    bool autoCorrect() const { return m_autoCorrect; }
+
     QPointF contentPos() const;
     void setContentPos(const QPointF&);
 
@@ -193,6 +196,7 @@ protected:
     bool m_navigatorQtObjectEnabled;
     bool m_renderToOffscreenBuffer;
     bool m_allowAnyHTTPSCertificateForLocalHost;
+    bool m_autoCorrect;
     WTF::String m_iconUrl;
     int m_loadProgress;
     WTF::String m_currentUrl;


### PR DESCRIPTION
autoCorrect property is part of experimental API and disabled by default
