### PR TITLE
[qtwebkit] Add experimental customLayoutWidth property

### DIFF
--- a/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview_p.h
+++ b/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview_p.h
@@ -256,6 +256,7 @@ class QWEBKIT_EXPORT QQuickWebViewExperimental : public QObject {
     Q_PROPERTY(int preferredMinimumContentsWidth WRITE setPreferredMinimumContentsWidth READ preferredMinimumContentsWidth NOTIFY preferredMinimumContentsWidthChanged)
     Q_PROPERTY(int deviceWidth WRITE setDeviceWidth READ deviceWidth NOTIFY deviceWidthChanged)
     Q_PROPERTY(int deviceHeight WRITE setDeviceHeight READ deviceHeight NOTIFY deviceHeightChanged)
+    Q_PROPERTY(int customLayoutWidth WRITE setCustomLayoutWidth READ customLayoutWidth NOTIFY customLayoutWidthChanged)
 
     Q_PROPERTY(bool autoCorrect WRITE setAutoCorrect READ autoCorrect NOTIFY autoCorrectChanged)
     Q_PROPERTY(bool temporaryCookies WRITE setTemporaryCookies READ temporaryCookies NOTIFY temporaryCookiesChanged FINAL)
@@ -341,6 +342,9 @@ public:
     int preferredMinimumContentsWidth() const;
     void setPreferredMinimumContentsWidth(int);
 
+    int customLayoutWidth() const;
+    void setCustomLayoutWidth(int);
+
     bool autoCorrect() const;
     void setAutoCorrect(bool autoCorrect);
 
@@ -352,6 +356,8 @@ public:
     void setRenderToOffscreenBuffer(bool enable);
     static void setFlickableViewportEnabled(bool enable);
     static bool flickableViewportEnabled();
+
+    bool firstFrameRendered() const;
 
 public Q_SLOTS:
     void goBackTo(int index);
@@ -385,6 +391,7 @@ Q_SIGNALS:
     void preferredMinimumContentsWidthChanged();
     void remoteInspectorUrlChanged();
     void autoCorrectChanged();
+    void customLayoutWidthChanged();
     void temporaryCookiesChanged();
 
 private:

--- a/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview_p_p.h
+++ b/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview_p_p.h
@@ -193,7 +193,10 @@ protected:
 
     QList<QUrl> userScripts;
 
+    bool m_firstFrameRendered;
     bool m_betweenLoadCommitAndFirstFrame;
+    int m_customLayoutWidth;
+    bool m_relayoutRequested;
     bool m_useDefaultContentItemSize;
     bool m_navigatorQtObjectEnabled;
     bool m_renderToOffscreenBuffer;

--- a/qtwebkit/Source/WebKit2/UIProcess/qt/PageViewportControllerClientQt.cpp
+++ b/qtwebkit/Source/WebKit2/UIProcess/qt/PageViewportControllerClientQt.cpp
@@ -507,7 +507,8 @@ void PageViewportControllerClientQt::didChangeContentsSize(const IntSize& newSiz
     // we didn't do scale adjustment.
     emit m_viewportItem->experimental()->test()->contentsScaleCommitted();
 
-    if (!m_scaleChange.inProgress() && !m_scrollChange.inProgress())
+    if (!m_scaleChange.inProgress() && !m_scrollChange.inProgress()
+            && m_viewportItem->experimental()->firstFrameRendered())
         setContentsRectToNearestValidBounds();
 }
 


### PR DESCRIPTION
Add experimental customLayoutWidth property. Changes to this property during runtime do not trigger layouting request. Only effective on after loading. This causes 2nd rendering pass.

WebKit applies customLayoutWidth if it find it possible e.g. not explicit content width defined.
