### PR TITLE
[qtwebkit] Change adjusted positioning only to be used for scaling opera...

### DIFF
--- a/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebpage.cpp
+++ b/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebpage.cpp
@@ -155,14 +155,14 @@ QPointF QQuickWebPage::adjustedPosition() const
     return QPointF(xPos, yPos);
 }
 
-QTransform QQuickWebPage::transformFromItem() const
+QTransform QQuickWebPage::transformFromItem(bool adjusted) const
 {
-    return transformToItem().inverted();
+    return transformToItem(adjusted).inverted();
 }
 
-QTransform QQuickWebPage::transformToItem() const
+QTransform QQuickWebPage::transformToItem(bool adjusted) const
 {
-    QPointF pos = adjustedPosition();
+    QPointF pos = adjusted ? adjustedPosition() : position();
     qreal xPos = pos.x();
     qreal yPos = pos.y();
 

--- a/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebpage_p.h
+++ b/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebpage_p.h
@@ -47,8 +47,8 @@ public:
     qreal contentsScale() const;
     QPointF adjustedPosition() const;
 
-    QTransform transformFromItem() const;
-    QTransform transformToItem() const;
+    QTransform transformFromItem(bool adjusted = false) const;
+    QTransform transformToItem(bool adjusted = false) const;
 
     WebKit::QtWebPageEventHandler* eventHandler() const;
 

--- a/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview.cpp
+++ b/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview.cpp
@@ -1815,7 +1815,7 @@ bool QQuickWebView::loading() const
 QPointF QQuickWebView::mapToWebContent(const QPointF& pointInViewCoordinates) const
 {
     Q_D(const QQuickWebView);
-    return d->pageView->transformFromItem().map(pointInViewCoordinates);
+    return d->pageView->transformFromItem(true).map(pointInViewCoordinates);
 }
 
 /*!
@@ -1825,7 +1825,7 @@ QPointF QQuickWebView::mapToWebContent(const QPointF& pointInViewCoordinates) co
 QRectF QQuickWebView::mapRectToWebContent(const QRectF& rectInViewCoordinates) const
 {
     Q_D(const QQuickWebView);
-    return d->pageView->transformFromItem().mapRect(rectInViewCoordinates);
+    return d->pageView->transformFromItem(true).mapRect(rectInViewCoordinates);
 }
 
 /*!
@@ -1835,7 +1835,7 @@ QRectF QQuickWebView::mapRectToWebContent(const QRectF& rectInViewCoordinates) c
 QPointF QQuickWebView::mapFromWebContent(const QPointF& pointInCSSCoordinates) const
 {
     Q_D(const QQuickWebView);
-    return d->pageView->transformToItem().map(pointInCSSCoordinates);
+    return d->pageView->transformToItem(true).map(pointInCSSCoordinates);
 }
 
 /*!
@@ -1844,7 +1844,7 @@ QPointF QQuickWebView::mapFromWebContent(const QPointF& pointInCSSCoordinates) c
 QRectF QQuickWebView::mapRectFromWebContent(const QRectF& rectInCSSCoordinates) const
 {
     Q_D(const QQuickWebView);
-    return d->pageView->transformToItem().mapRect(rectInCSSCoordinates);
+    return d->pageView->transformToItem(true).mapRect(rectInCSSCoordinates);
 }
 
 /*!


### PR DESCRIPTION
...tions.

In practice only PageViewportControllerClientQt uses adjusted positions.
Event handling in QtWebPageEventHandler uses normal position.
