### PR TITLE
[packaging] Revert: "Add inlined functions to common config.h that is included by us...

### DIFF
--- a/qtwebkit/Source/JavaScriptCore/config.h
+++ b/qtwebkit/Source/JavaScriptCore/config.h
@@ -66,8 +66,6 @@
 #endif
 
 #include <wtf/DisallowCType.h>
-#include "JSCellInlines.h"
-#include "JSDestructibleObject.h"
 
 #if COMPILER(MSVC)
 #define SKIP_STATIC_CONSTRUCTORS_ON_MSVC 1


### PR DESCRIPTION
...ers"

Revert commit be0cb063458de4d3dbbba45e035106a3118815a8

x86 build got broken and it seems that removing fuse-ld=gold is enough.
