### PR TITLE
[qtwebkit] Introduce experimental.offline property

### DIFF
--- a/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview.cpp
+++ b/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview.cpp
@@ -814,6 +814,18 @@ bool QQuickWebViewPrivate::handleCertificateVerificationRequest(const QString& h
     return dialogRunner.wasAccepted();
 }
 
+void QQuickWebViewPrivate::handleNetworkRequestIgnored()
+{
+    Q_Q(QQuickWebView);
+    emit q->experimental()->networkRequestIgnored();
+}
+
+void QQuickWebViewPrivate::handleOfflineChanged(bool state)
+{
+    Q_Q(QQuickWebView);
+    q->experimental()->handleOfflineChanged(state);
+}
+
 void QQuickWebViewPrivate::chooseFiles(WKOpenPanelResultListenerRef listenerRef, const QStringList& selectedFileNames, QtWebPageUIClient::FileChooserType type)
 {
     Q_Q(QQuickWebView);
@@ -1152,6 +1164,7 @@ QQuickWebViewExperimental::QQuickWebViewExperimental(QQuickWebView *webView, QQu
     , d_ptr(webViewPrivate)
     , schemeParent(new QObject(this))
     , m_test(new QWebKitTest(webViewPrivate, this))
+    , m_offline(0)
 {
 }
 
@@ -1265,6 +1278,26 @@ void QQuickWebViewExperimental::setTemporaryCookies(bool enable)
 
     d->m_temporaryCookies = enable;
     emit temporaryCookiesChanged();
+}
+
+bool QQuickWebViewExperimental::offline() const
+{
+    return m_offline;
+}
+
+void QQuickWebViewExperimental::setOffline(bool state)
+{
+    Q_D(const QQuickWebView);
+    d->webPageProxy->setOffline(state);
+}
+
+void QQuickWebViewExperimental::handleOfflineChanged(bool state)
+{
+    if (state == m_offline)
+        return;
+
+    m_offline = state;
+    emit offlineChanged();
 }
 
 void QQuickWebViewExperimental::setFlickableViewportEnabled(bool enable)

--- a/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview_p.h
+++ b/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview_p.h
@@ -265,6 +265,7 @@ class QWEBKIT_EXPORT QQuickWebViewExperimental : public QObject {
 
     Q_PROPERTY(bool autoCorrect WRITE setAutoCorrect READ autoCorrect NOTIFY autoCorrectChanged)
     Q_PROPERTY(bool temporaryCookies WRITE setTemporaryCookies READ temporaryCookies NOTIFY temporaryCookiesChanged FINAL)
+    Q_PROPERTY(bool offline WRITE setOffline READ offline NOTIFY offlineChanged FINAL)
 
     Q_PROPERTY(QWebNavigationHistory* navigationHistory READ navigationHistory CONSTANT FINAL)
 
@@ -373,7 +374,11 @@ public:
     bool temporaryCookies() const;
     void setTemporaryCookies(bool enable);
 
+    bool offline() const;
+    void setOffline(bool state);
+
     // C++ only
+    void handleOfflineChanged(bool state);
     bool renderToOffscreenBuffer() const;
     void setRenderToOffscreenBuffer(bool enable);
     static void setFlickableViewportEnabled(bool enable);
@@ -420,11 +425,13 @@ Q_SIGNALS:
     void overviewChanged();
     void temporaryCookiesChanged();
     void textFound(int matchCount);
+    void offlineChanged();
 
     void processDidCrash();
     void didRelaunchProcess();
     void processDidBecomeUnresponsive();
     void processDidBecomeResponsive();
+    void networkRequestIgnored();
 
 private:
     QQuickWebViewExperimental(QQuickWebView* webView, QQuickWebViewPrivate* webViewPrivate);
@@ -432,6 +439,7 @@ private:
     QQuickWebViewPrivate* d_ptr;
     QObject* schemeParent;
     QWebKitTest* m_test;
+    bool m_offline;
 
     friend class WebKit::QtWebPageUIClient;
 

--- a/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview_p_p.h
+++ b/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview_p_p.h
@@ -114,6 +114,8 @@ public:
     void handleAuthenticationRequiredRequest(const QString& hostname, const QString& realm, const QString& prefilledUsername, QString& username, QString& password);
     bool handleCertificateVerificationRequest(const QString& hostname);
     void handleProxyAuthenticationRequiredRequest(const QString& hostname, uint16_t port, const QString& prefilledUsername, QString& username, QString& password);
+    void handleNetworkRequestIgnored();
+    void handleOfflineChanged(bool state);
 
     void setRenderToOffscreenBuffer(bool enable) { m_renderToOffscreenBuffer = enable; }
     void setTransparentBackground(bool);

--- a/qtwebkit/Source/WebKit2/UIProcess/API/qt/raw/qrawwebview.cpp
+++ b/qtwebkit/Source/WebKit2/UIProcess/API/qt/raw/qrawwebview.cpp
@@ -62,6 +62,16 @@ void QRawWebViewPrivate::handleProxyAuthenticationRequiredRequest(const String& 
     notImplemented();
 }
 
+void QRawWebViewPrivate::handleNetworkRequestIgnored()
+{
+    notImplemented();
+}
+
+void QRawWebViewPrivate::handleOfflineChanged(bool state)
+{
+    notImplemented();
+}
+
 void QRawWebViewPrivate::registerEditCommand(PassRefPtr<WebKit::WebEditCommandProxy>, WebKit::WebPageProxy::UndoOrRedo)
 {
     notImplemented();

--- a/qtwebkit/Source/WebKit2/UIProcess/API/qt/raw/qrawwebview_p_p.h
+++ b/qtwebkit/Source/WebKit2/UIProcess/API/qt/raw/qrawwebview_p_p.h
@@ -48,6 +48,8 @@ public:
     virtual void handleAuthenticationRequiredRequest(const String& hostname, const String& realm, const String& prefilledUsername, String& username, String& password);
     virtual void handleCertificateVerificationRequest(const String& hostname, bool& ignoreErrors);
     virtual void handleProxyAuthenticationRequiredRequest(const String& hostname, uint16_t port, const String& prefilledUsername, String& username, String& password);
+    virtual void handleNetworkRequestIgnored();
+    virtual void handleOfflineChanged(bool state);
 
     virtual void registerEditCommand(PassRefPtr<WebKit::WebEditCommandProxy>, WebKit::WebPageProxy::UndoOrRedo);
     virtual bool canUndoRedo(WebKit::WebPageProxy::UndoOrRedo undoOrRedo);

--- a/qtwebkit/Source/WebKit2/UIProcess/PageClient.h
+++ b/qtwebkit/Source/WebKit2/UIProcess/PageClient.h
@@ -129,6 +129,8 @@ public:
     virtual void handleCertificateVerificationRequest(const String& hostname, bool& ignoreErrors) = 0;
     virtual void handleProxyAuthenticationRequiredRequest(const String& hostname, uint16_t port, const String& prefilledUsername, String& username, String& password) = 0;
     virtual void handleWillSetInputMethodState() = 0;
+    virtual void handleNetworkRequestIgnored() = 0;
+    virtual void handleOfflineChanged(bool state) = 0;
 #endif // PLATFORM(QT).
 
 #if PLATFORM(QT) || PLATFORM(EFL) || PLATFORM(GTK)

--- a/qtwebkit/Source/WebKit2/UIProcess/WebPageProxy.h
+++ b/qtwebkit/Source/WebKit2/UIProcess/WebPageProxy.h
@@ -365,11 +365,14 @@ public:
 #endif
 #if PLATFORM(QT)
     void registerApplicationScheme(const String& scheme);
+    void setOffline(bool state);
     void resolveApplicationSchemeRequest(QtNetworkRequestData);
     void sendApplicationSchemeReply(const QQuickNetworkReply*);
     void authenticationRequiredRequest(const String& hostname, const String& realm, const String& prefilledUsername, String& username, String& password);
     void certificateVerificationRequest(const String& hostname, bool& ignoreErrors);
     void proxyAuthenticationRequiredRequest(const String& hostname, uint16_t port, const String& prefilledUsername, String& username, String& password);
+    void networkRequestIgnored();
+    void offlineChanged(bool value);
 #endif // PLATFORM(QT).
 #if PLATFORM(EFL)
     void setThemePath(const String&);

--- a/qtwebkit/Source/WebKit2/UIProcess/WebPageProxy.messages.in
+++ b/qtwebkit/Source/WebKit2/UIProcess/WebPageProxy.messages.in
@@ -84,6 +84,8 @@ messages -> WebPageProxy {
     AuthenticationRequiredRequest(WTF::String hostname, WTF::String realm, WTF::String prefilledUsername) -> (WTF::String username, WTF::String password)
     CertificateVerificationRequest(WTF::String hostname) -> (bool ignoreErrors)
     ProxyAuthenticationRequiredRequest(WTF::String hostname, uint16_t port, WTF::String prefilledUsername) -> (WTF::String username, WTF::String password)
+    NetworkRequestIgnored()
+    OfflineChanged(bool state)
 #endif
 
 #if PLATFORM(QT) || PLATFORM(EFL)

--- a/qtwebkit/Source/WebKit2/UIProcess/qt/QtPageClient.cpp
+++ b/qtwebkit/Source/WebKit2/UIProcess/qt/QtPageClient.cpp
@@ -154,6 +154,16 @@ void QtPageClient::handleProxyAuthenticationRequiredRequest(const String& hostna
     password = qPassword;
 }
 
+void QtPageClient::handleNetworkRequestIgnored()
+{
+    QQuickWebViewPrivate::get(m_webView)->handleNetworkRequestIgnored();
+}
+
+void QtPageClient::handleOfflineChanged(bool state)
+{
+    QQuickWebViewPrivate::get(m_webView)->handleOfflineChanged(state);
+}
+
 void QtPageClient::setCursor(const WebCore::Cursor& cursor)
 {
     // FIXME: This is a temporary fix until we get cursor support in QML items.

--- a/qtwebkit/Source/WebKit2/UIProcess/qt/QtPageClient.h
+++ b/qtwebkit/Source/WebKit2/UIProcess/qt/QtPageClient.h
@@ -58,6 +58,8 @@ public:
     virtual void handleAuthenticationRequiredRequest(const String& hostname, const String& realm, const String& prefilledUsername, String& username, String& password);
     virtual void handleCertificateVerificationRequest(const String& hostname, bool& ignoreErrors);
     virtual void handleProxyAuthenticationRequiredRequest(const String& hostname, uint16_t port, const String& prefilledUsername, String& username, String& password);
+    virtual void handleNetworkRequestIgnored();
+    virtual void handleOfflineChanged(bool state);
 
     virtual void displayView();
     virtual bool canScrollView() { return false; }

--- a/qtwebkit/Source/WebKit2/UIProcess/qt/WebPageProxyQt.cpp
+++ b/qtwebkit/Source/WebKit2/UIProcess/qt/WebPageProxyQt.cpp
@@ -65,6 +65,11 @@ void WebPageProxy::registerApplicationScheme(const String& scheme)
     process()->send(Messages::WebPage::RegisterApplicationScheme(scheme), m_pageID);
 }
 
+void WebPageProxy::setOffline(bool state)
+{
+    process()->send(Messages::WebPage::SetOffline(state), m_pageID);
+}
+
 void WebPageProxy::resolveApplicationSchemeRequest(QtNetworkRequestData request)
 {
 #if HAVE(QTQUICK)
@@ -99,6 +104,16 @@ void WebPageProxy::proxyAuthenticationRequiredRequest(const String& hostname, ui
 void WebPageProxy::certificateVerificationRequest(const String& hostname, bool& ignoreErrors)
 {
     m_pageClient->handleCertificateVerificationRequest(hostname, ignoreErrors);
+}
+
+void WebPageProxy::networkRequestIgnored()
+{
+    m_pageClient->handleNetworkRequestIgnored();
+}
+
+void WebPageProxy::offlineChanged(bool state)
+{
+    m_pageClient->handleOfflineChanged(state);
 }
 
 #if PLUGIN_ARCHITECTURE(X11)

--- a/qtwebkit/Source/WebKit2/WebProcess/WebPage/WebPage.h
+++ b/qtwebkit/Source/WebKit2/WebProcess/WebPage/WebPage.h
@@ -586,6 +586,7 @@ public:
 
 #if PLATFORM(QT)
     void registerApplicationScheme(const String& scheme);
+    void setOffline(bool state);
     void applicationSchemeReply(const QtNetworkReplyData&);
     void receivedApplicationSchemeRequest(const QNetworkRequest&, QtNetworkReply*);
     void setUserScripts(const Vector<String>&);

--- a/qtwebkit/Source/WebKit2/WebProcess/WebPage/WebPage.messages.in
+++ b/qtwebkit/Source/WebKit2/WebProcess/WebPage/WebPage.messages.in
@@ -79,6 +79,7 @@ messages -> WebPage LegacyReceiver {
 
 #if PLATFORM(QT)
     ApplicationSchemeReply(WebKit::QtNetworkReplyData reply)
+    SetOffline(bool value)
     RegisterApplicationScheme(WTF::String scheme)
 #endif
 

--- a/qtwebkit/Source/WebKit2/WebProcess/WebPage/qt/WebPageQt.cpp
+++ b/qtwebkit/Source/WebKit2/WebProcess/WebPage/qt/WebPageQt.cpp
@@ -306,6 +306,14 @@ void WebPage::registerApplicationScheme(const String& scheme)
     qnam->registerApplicationScheme(this, QString(scheme));
 }
 
+void WebPage::setOffline(bool state)
+{
+    QtNetworkAccessManager* qnam = qobject_cast<QtNetworkAccessManager*>(WebProcess::shared().networkAccessManager());
+    if (!qnam)
+        return;
+    qnam->setOffline(state, m_pageID);
+}
+
 void WebPage::receivedApplicationSchemeRequest(const QNetworkRequest& request, QtNetworkReply* reply)
 {
     QtNetworkRequestData requestData(request, reply);

--- a/qtwebkit/Source/WebKit2/WebProcess/qt/QtNetworkAccessManager.h
+++ b/qtwebkit/Source/WebKit2/WebProcess/qt/QtNetworkAccessManager.h
@@ -42,6 +42,7 @@ class QtNetworkAccessManager : public QNetworkAccessManager {
 public:
     QtNetworkAccessManager(WebProcess*);
     void registerApplicationScheme(const WebPage*, const QString& scheme);
+    void setOffline(bool state, qulonglong pageId);
 
 protected:
     virtual QNetworkReply* createRequest(Operation, const QNetworkRequest&, QIODevice* outgoingData = 0) OVERRIDE;
@@ -56,6 +57,7 @@ private:
 
     QMultiHash<const WebPage*, QString> m_applicationSchemes;
     WebProcess* m_webProcess;
+    bool m_offline;
 
 };
 

--- a/rpm/qtwebkit5.spec
+++ b/rpm/qtwebkit5.spec
@@ -3,7 +3,7 @@
 
 Name:       qt5-qtwebkit
 Summary:    Web content engine library for Qt
-Version:    5.1.0
+Version:    5.1.0+git13
 Release:    1%{?dist}
 Group:      Qt/Qt
 License:    BSD and LGPLv2+


### PR DESCRIPTION
experimental.offline will make current WebView instance offline when true,
any external network requests will produce a empty reply and
experimental.networkRequestIgnored() signal will be emited for each external
request attempt.
