### PR TITLE
[qtwebkit] Do not block link hovering based on previous link

### DIFF
--- a/qtwebkit/Source/WebKit2/UIProcess/qt/QtWebPageUIClient.cpp
+++ b/qtwebkit/Source/WebKit2/UIProcess/qt/QtWebPageUIClient.cpp
@@ -79,11 +79,7 @@ void QtWebPageUIClient::runOpenPanel(WKOpenPanelResultListenerRef listenerRef, c
 
 void QtWebPageUIClient::mouseDidMoveOverElement(const QUrl& linkURL, const QString& linkTitle)
 {
-    if (linkURL == m_lastHoveredURL && linkTitle == m_lastHoveredTitle)
-        return;
-    m_lastHoveredURL = linkURL;
-    m_lastHoveredTitle = linkTitle;
-    emit m_webView->linkHovered(m_lastHoveredURL, m_lastHoveredTitle);
+    emit m_webView->linkHovered(linkURL, linkTitle);
 }
 
 void QtWebPageUIClient::permissionRequest(QWebPermissionRequest* request)

--- a/qtwebkit/Source/WebKit2/UIProcess/qt/QtWebPageUIClient.h
+++ b/qtwebkit/Source/WebKit2/UIProcess/qt/QtWebPageUIClient.h
@@ -62,8 +62,6 @@ private:
     static void policyForNotificationPermissionRequest(WKPageRef, WKSecurityOriginRef, WKNotificationPermissionRequestRef, const void*);
 
     QQuickWebView* m_webView;
-    QUrl m_lastHoveredURL;
-    QString m_lastHoveredTitle;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
Clicking / hovering the same link again didn't emit linkHovered.
