### PR TITLE
[qtwebkit] Disable persistent SG/GL when WebView is used.

### DIFF
--- a/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebpage.cpp
+++ b/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebpage.cpp
@@ -76,7 +76,7 @@ QSGNode* QQuickWebPage::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData*)
 
     QtWebPageSGNode* node = static_cast<QtWebPageSGNode*>(oldNode);
 
-    const QWindow* window = this->window();
+    QQuickWindow* window = this->window();
     ASSERT(window);
 
     WKPageRef pageRef = webViewPrivate->webPage.get();
@@ -87,8 +87,11 @@ QSGNode* QQuickWebPage::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData*)
         emit d->viewportItem->experimental()->test()->devicePixelRatioChanged();
     }
 
-    if (!node)
+    if (!node) {
         node = new QtWebPageSGNode;
+        window->setPersistentOpenGLContext(true);
+        window->setPersistentSceneGraph(true);
+    }
 
     node->setCoordinatedGraphicsScene(scene);
 


### PR DESCRIPTION
It is not working and this prevents webkit from invalidating itself
which will result in blank views and potentially crashes.
