### PR TITLE
[build] Fix build on x11 based systems

### DIFF
--- a/rpm/qtwebkit5.spec
+++ b/rpm/qtwebkit5.spec
@@ -179,7 +179,11 @@ qmake -qt=5 CONFIG+=release CONFIG-=debug \
        WEBKIT_CONFIG-=svg \
        WEBKIT_CONFIG-=inspector \
        WEBKIT_CONFIG-=fullscreen_api \
+%if %{with X11}
+       WEBKIT_CONFIG+=netscape_plugin_api \
+%else
        WEBKIT_CONFIG-=netscape_plugin_api \
+%endif
        WEBKIT_CONFIG-=build_qttestsupport
 
 make %{?jobs:-j%jobs}


### PR DESCRIPTION
The spec files expects QtWebPluginProcess to be built, but the configure options disabled the build for that module...

So, if we're on x11 based systems we just add it back
