### PR TITLE
[qtwebkit] Added experimental.repositionInputField property

### DIFF
--- a/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview.cpp
+++ b/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview.cpp
@@ -316,6 +316,7 @@ QQuickWebViewPrivate::QQuickWebViewPrivate(QQuickWebView* viewport)
     , m_autoCorrect(false)
     , m_temporaryCookies(false)
     , m_loadProgress(0)
+    , m_enableInputFieldAnimation(true)
 {
     viewport->setClip(true);
     viewport->setPixelAligned(true);
@@ -1348,6 +1349,37 @@ bool QQuickWebViewExperimental::firstFrameRendered() const
 {
      Q_D(const QQuickWebView);
     return d->m_firstFrameRendered;
+}
+
+
+bool QQuickWebViewExperimental::enableInputFieldAnimation() const
+{
+    Q_D(const QQuickWebView);
+    return d->m_enableInputFieldAnimation;
+}
+
+void QQuickWebViewExperimental::setEnableInputFieldAnimation(bool enableInputFieldAnimation)
+{
+    Q_D(QQuickWebView);
+
+    if (d->m_enableInputFieldAnimation == enableInputFieldAnimation)
+        return;
+
+    d->m_enableInputFieldAnimation = enableInputFieldAnimation;
+    emit enableInputFieldAnimationChanged();
+}
+
+void QQuickWebViewExperimental::animateInputFieldVisible()
+{
+    Q_D(QQuickWebView);
+
+    const EditorState& editor = d->webPageProxy->editorState();
+    if (editor.isContentEditable) {
+        PageViewportControllerClientQt* viewportControllerClient = d->viewportControllerClient();
+        if (viewportControllerClient) {
+            viewportControllerClient->focusEditableArea(QRectF(editor.cursorRect), QRectF(editor.editorRect), true);
+        }
+    }
 }
 
 /*!

--- a/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview_p.h
+++ b/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview_p.h
@@ -291,6 +291,7 @@ class QWEBKIT_EXPORT QQuickWebViewExperimental : public QObject {
     Q_PROPERTY(QList<QUrl> userScripts READ userScripts WRITE setUserScripts NOTIFY userScriptsChanged)
     Q_PROPERTY(QUrl userStyleSheet READ userStyleSheet WRITE setUserStyleSheet NOTIFY userStyleSheetChanged)
     Q_PROPERTY(QUrl remoteInspectorUrl READ remoteInspectorUrl NOTIFY remoteInspectorUrlChanged FINAL)
+    Q_PROPERTY(bool enableInputFieldAnimation READ enableInputFieldAnimation WRITE setEnableInputFieldAnimation NOTIFY enableInputFieldAnimationChanged)
     Q_ENUMS(NavigationRequestActionExperimental)
     Q_FLAGS(FindFlags)
 
@@ -344,6 +345,10 @@ public:
     QUrl userStyleSheet() const;
     void setUserStyleSheet(const QUrl& userStyleSheet);
     QUrl remoteInspectorUrl() const;
+    bool enableInputFieldAnimation() const;
+    void setEnableInputFieldAnimation(bool enableInputFieldAnimation);
+
+    Q_INVOKABLE void animateInputFieldVisible();
 
     QWebKitTest* test();
 
@@ -432,6 +437,7 @@ Q_SIGNALS:
     void customLayoutWidthChanged();
     void overviewChanged();
     void pinchingChanged();
+    void enableInputFieldAnimationChanged();
 
     void temporaryCookiesChanged();
     void textFound(int matchCount);

--- a/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview_p_p.h
+++ b/qtwebkit/Source/WebKit2/UIProcess/API/qt/qquickwebview_p_p.h
@@ -92,6 +92,8 @@ public:
     void didRenderFrame();
 
     virtual WebKit::PageViewportController* viewportController() const { return 0; }
+    virtual WebKit::PageViewportControllerClientQt* viewportControllerClient() const { return 0; }
+
     virtual void updateViewportSize() { }
     void updateTouchViewportSize();
 
@@ -242,6 +244,7 @@ protected:
     int m_loadProgress;
     QString m_currentUrl;
     bool m_pinching;
+    bool m_enableInputFieldAnimation;
 };
 
 class QQuickWebViewLegacyPrivate : public QQuickWebViewPrivate {
@@ -266,6 +269,7 @@ public:
 
     virtual void didChangeViewportProperties(const WebCore::ViewportAttributes&);
     virtual WebKit::PageViewportController* viewportController() const { return m_pageViewportController.data(); }
+    virtual WebKit::PageViewportControllerClientQt* viewportControllerClient() const { return m_pageViewportControllerClient.data(); }
     virtual void updateViewportSize();
 
     virtual void pageDidRequestScroll(const QPoint& pos);

--- a/qtwebkit/Source/WebKit2/UIProcess/qt/PageViewportControllerClientQt.cpp
+++ b/qtwebkit/Source/WebKit2/UIProcess/qt/PageViewportControllerClientQt.cpp
@@ -208,10 +208,15 @@ void PageViewportControllerClientQt::touchEnd()
     m_touchInteraction.end();
 }
 
-void PageViewportControllerClientQt::focusEditableArea(const QRectF& caretArea, const QRectF& targetArea)
+void PageViewportControllerClientQt::focusEditableArea(const QRectF& caretArea,
+                                                       const QRectF& targetArea,
+                                                       bool userTriggered)
 {
     // This can only happen as a result of a user interaction.
     ASSERT(m_controller->hadUserInteraction());
+
+    if (!userTriggered && m_viewportItem->experimental()->enableInputFieldAnimation() == false)
+        return;
 
     const float editingFixedScale = 2;
     float targetScale = m_controller->innerBoundedViewportScale(editingFixedScale);

--- a/qtwebkit/Source/WebKit2/UIProcess/qt/PageViewportControllerClientQt.h
+++ b/qtwebkit/Source/WebKit2/UIProcess/qt/PageViewportControllerClientQt.h
@@ -77,7 +77,7 @@ public:
     void pinchGestureCancelled();
 
     void zoomToAreaGestureEnded(const QPointF& touchPoint, const QRectF& targetArea);
-    void focusEditableArea(const QRectF& caretArea, const QRectF& targetArea);
+    void focusEditableArea(const QRectF& caretArea, const QRectF& targetArea, bool userTriggered = false);
 
 private Q_SLOTS:
     // Respond to changes of position that are not driven by us.


### PR DESCRIPTION
Added possibility to turn off automatic repositioning and scaling
animation when edit field is focused and possibility to later
trigger it from client code through WebView.experimental